### PR TITLE
fix app recognition issue of intellij in ubuntu

### DIFF
--- a/client/src/main/execute/system.ts
+++ b/client/src/main/execute/system.ts
@@ -53,8 +53,6 @@ export default class System {
     const result = (await driver.getActiveApplication()).toLowerCase();
     if (result === "system dialog") {
       return "system dialog";
-    } else if (result.includes("atom")) {
-      return "atom";
     } else if (
       result.includes("visualstudiocode") ||
       result.includes("visual studio code") ||
@@ -102,6 +100,8 @@ export default class System {
       return "terminal";
     } else if (result.includes("slack")) {
       return "slack";
+    } else if (result.includes("atom")) {
+      return "atom";
     } else if (result.includes("electron") || result.includes("serenade")) {
       return "serenade";
     }


### PR DESCRIPTION
**Approved Issue: https://github.com/serenadeai/serenade/issues/25**

## Description

I've moved the check for the Atom editor to the end of the if-else statement. Since the term atom can be found in other applications, such as "atomic" in IntelliJ.

## Test Plan

Tested manually on the Ubuntu machine.

## Pre-Review Checklist

[ ] I've performed a self-review of my own code
[ ] I've run the pre-commit hook to enforce code style
[ ] I've added or corresponding updated tests
[ ] I've run all tests and there were no failures
[ ] I've updated the documentation, if applicable
